### PR TITLE
Fix issue with social icons wrapping to left at larger screen widths

### DIFF
--- a/src/styles/landing.module.css
+++ b/src/styles/landing.module.css
@@ -44,6 +44,7 @@
 .contactInfo {
   text-align: center;
   font-weight: 300;
+  clear: both;
 }
 
 .socialIcons {


### PR DESCRIPTION
The social network icons on your home/landing page wrap towards the left of the viewport at larger (~2000px+) widths.  At that size, the `float`-ed `.surroundingDiv` has just enough space to the left to allow the icons to creep up.

![image](https://user-images.githubusercontent.com/201370/71419146-9e585c80-2633-11ea-9da5-73a375e00fc4.png)
![image](https://user-images.githubusercontent.com/201370/71419157-a7492e00-2633-11ea-9d35-2cd54323bae9.png)

https://www.loom.com/share/e1ae94b5cd854562ae008f1dda6e2839

I propose adding `clear: both;` to force the entire container back down past the floated image.

![image](https://user-images.githubusercontent.com/201370/71419253-22124900-2634-11ea-825f-79ee1e7d3910.png)

